### PR TITLE
reworks the logic of the navbar

### DIFF
--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -3,7 +3,7 @@ import styles from './Hero.module.css';
 
 export function Hero() {
   return (
-    <section className={styles.heroSection}>
+    <section id="Hero" className={styles.heroSection}>
       <div className={styles.content}>
         <p className={styles.subtitle}>Manuel Reyes</p>
         <h1 className={styles.title}>

--- a/src/components/Navbar/Navbar.module.css
+++ b/src/components/Navbar/Navbar.module.css
@@ -5,9 +5,17 @@
     background-color: var(--mantine-color-blue-dark, #1565c0);
     padding: 1rem 2rem;
     color: white;
+    z-index: 1000;
+    transition: position 0.3s ease;
+}
+
+.sticky {
     position: sticky;
     top: 0;
-    z-index: 1000;
+}
+
+.relative {
+    position: relative;
 }
 
 .logo {
@@ -35,4 +43,18 @@
 
 .navLinks li a:hover {
     color: var(--mantine-color-blue-accent, #0d47a1);
+}
+
+.navButton {
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
+    cursor: pointer;
+    padding: 0;
+}
+
+.navButton:hover {
+    text-decoration: none;
+    color: #0077cc; /* Optional hover color */
 }

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -1,29 +1,64 @@
-import { Link } from 'react-scroll';
-import { NavLink } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { scroller } from 'react-scroll';
 import styles from './Navbar.module.css';
 
 export function Navbar() {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const handleScrollNavigation = (sectionId: string) => {
+    if (location.pathname !== '/') {
+      // Navigate to the home page first
+      navigate('/');
+      setTimeout(() => {
+        // Scroll to the specific section after navigating
+        scroller.scrollTo(sectionId, {
+          duration: 500,
+          smooth: true,
+          offset: -70, // Adjust for navbar height if needed
+        });
+      }, 500); // Delay to ensure the page has loaded
+    } else {
+      // If already on the home page, scroll directly
+      scroller.scrollTo(sectionId, {
+        duration: 500,
+        smooth: true,
+        offset: -70,
+      });
+    }
+  };
+
+  // Determine navbar position based on the current route
+  const navbarClass =
+    location.pathname === '/' ? `${styles.navbar} ${styles.sticky}` : `${styles.navbar} ${styles.relative}`;
+
   return (
-    <nav className={styles.navbar}>
+    <nav className={navbarClass}>
       <div className={styles.logo}>
-        <NavLink to="/">Manuel Reyes</NavLink>
+        <a href="/" className={styles.navButton}>
+          Manuel Reyes
+        </a>
       </div>
       <ul className={styles.navLinks}>
         <li>
-          <NavLink to="/">Home</NavLink>
+          <a href="/" className={styles.navButton}>
+            Home
+          </a>
         </li>
         <li>
-          <NavLink to="/resume">Resume</NavLink>
+          <a href="/resume" className={styles.navButton}>
+            Resume
+          </a>
         </li>
         <li>
-          <Link to="projects" smooth={true} offset={-70} duration={500}>
+          <button onClick={() => handleScrollNavigation('projects')} className={styles.navButton}>
             Projects
-          </Link>
+          </button>
         </li>
         <li>
-          <Link to="contact" smooth={true} offset={-70} duration={500}>
+          <button onClick={() => handleScrollNavigation('contact')} className={styles.navButton}>
             Contact
-          </Link>
+          </button>
         </li>
       </ul>
     </nav>


### PR DESCRIPTION
This patch is a redesign of the navbars's internal logic:

- Added logic to dynamically set the navbar's position to sticky on the home page and relative on all other pages using the location.pathname
- Buttons like "Projects" and "Contact" navigate to the home page if on another page, then scroll smoothly to the respective section using react-scroll.
- made it so that the home button acts as the absolute reset point by reloading the page at the hero section